### PR TITLE
Remove the option run tasks every time

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Heavily based on the `seed_migration` gem [found here](https://github.com/harrystech/seed_migration).
 
-For rails projects that need to run tasks on deployment that don't quite fit in the `db:migrate` and `seed:migrate` categories, this gem lets you run configured rake tasks `once` or `every` time the command is run.
+For rails projects that need to run tasks on deployment that don't quite fit in the `db:migrate` and `seed:migrate` categories, this gem migrates specified rake tasks and ensures they only run once.
 
 ## Installation
 
@@ -36,12 +36,6 @@ namespace :users do
   end
 end
 
-namespace :deployment do
-  # Run this on each deployment
-  task :restart_jboss => :environment do
-    FileUtils.touch(Rails.root.join('tmp', 'restart.txt'))
-  end
-end
 ```
 
 Create a file at `config/tasks.yml` with your rake migration configuration:
@@ -50,11 +44,6 @@ Create a file at `config/tasks.yml` with your rake migration configuration:
 tasks:
   user_name_migration:
     command: users:migrate_names
-    frequency: :once # default
-
-  restart_jboss:
-    command: deployment:restart_jboss
-    frequency: :every
 ```
 
 Then run the migration for your configured rake tasks:
@@ -63,19 +52,7 @@ Then run the migration for your configured rake tasks:
 $ bundle exec rake tasks:migrate
 == user_name_migration: migrating =============================================
 == user_name_migration: migrated (0.0191s) ====================================
-== restart_jboss: migrating ===================================================
-== restart_jboss: migrated (0.0005s) ==========================================
 ```
-
-Notice that the user name task should only be run once. If we re-run the rake task migration it will not be included:
-```
-$ bundle exec rake tasks:migrate
-== restart_jboss: migrating ===================================================
-== restart_jboss: migrated (0.0003s) ==========================================
-```
-
-
-
 
 ## Development
 

--- a/lib/rake/migrations/migrator.rb
+++ b/lib/rake/migrations/migrator.rb
@@ -6,11 +6,9 @@ class Rake::Migrations::Migrator
     end
   end
 
-  # tasks to run every time + tasks that haven't been run yet
+  # tasks that haven't been run yet
   def self.get_task_migrations
-    config.tasks.select do |task|
-      task.run_every_time? || manifest.tasks.exclude?(task)
-    end
+    config.tasks.select { |task| manifest.tasks.exclude?(task) }
   end
 
   def self.manifest

--- a/lib/rake/migrations/task.rb
+++ b/lib/rake/migrations/task.rb
@@ -1,29 +1,16 @@
 class Rake::Migrations::Task
 
-  RUN_ONCE       = :once
-  RUN_EVERY_TIME = :every
-
-  attr_reader :name, :command, :frequency
+  attr_reader :name, :command
 
   def initialize(name, attrs = {})
     @name      = name
     @command   = attrs[:command]
-    @frequency = attrs[:frequency] || RUN_ONCE
-  end
-
-  def run_every_time?
-    frequency == RUN_EVERY_TIME
-  end
-
-  def run_once?
-    frequency == RUN_ONCE
   end
 
   def to_h
     {
       name => {
-        command: command,
-        frequency: frequency
+        command: command
       }
     }
   end


### PR DESCRIPTION
It doesn't make much sense to "migrate" a task more than once. Fixes issue #2 
