### PR TITLE
Use namespace to determine task list

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Or install it yourself as:
 
 ## Usage
 
-Given a set of rake tasks you might need to run on deployment:
+Create the `lib/tasks/migrations.rake` file and add your tasks:
 
 ```ruby
-namespace :users do
+namespace :migrations do
   # Run this only once
-  task :migrate_names => :environment do
+  task :migrate_user_names => :environment do
     User.find_each do |user|
       user.update_attributes(name: "#{user.first_name} #{user.last_name}")
     end
@@ -38,21 +38,16 @@ end
 
 ```
 
-Create a file at `config/tasks.yml` with your rake migration configuration:
-
-```yml
-tasks:
-  user_name_migration:
-    command: users:migrate_names
-```
-
-Then run the migration for your configured rake tasks:
+Then run the migration for your rake tasks:
 
 ```
 $ bundle exec rake tasks:migrate
-== user_name_migration: migrating =============================================
-== user_name_migration: migrated (0.0191s) ====================================
+== migrate_user_names: migrating =============================================
+== migrate_user_names: migrated (0.0191s) ====================================
 ```
+
+Each rake task is run only once.
+
 
 ## Development
 

--- a/lib/rake/migrations/configuration.rb
+++ b/lib/rake/migrations/configuration.rb
@@ -1,24 +1,25 @@
 class Rake::Migrations::Configuration
 
-  DEFAULT_FILE_PATH = Rails.root.join('config', 'tasks.yml')
+  DEFAULT_NAMESPACE = :migrations
 
-  def self.load(file_path = DEFAULT_FILE_PATH)
-    config = new(file_path)
+  def self.load(namespace = DEFAULT_NAMESPACE)
+    config = new(namespace)
     config.load
     config
   end
 
-  attr_reader :file_path, :tasks
+  attr_reader :namespace, :tasks
 
-  def initialize(file_path)
-    @file_path = file_path
-    @tasks = []
+  def initialize(namespace)
+    @namespace = namespace
+    @tasks     = []
   end
 
   def load
-    config = YAML.load_file(file_path).with_indifferent_access
-    (config[:tasks] || []).each do |task|
-      add_task Rake::Migrations::Task.new(*task)
+    Rake.application.in_namespace(namespace) do |namespace|
+      namespace.tasks.each do |task|
+        add_task Rake::Migrations::Task.new(task.name, command: task.name)
+      end
     end
   end
 


### PR DESCRIPTION
This removes the dependency on a `config/tasks.yml` file being present
before the gem can be used. Now all it takes is having tasks in the
`migrations` namespace.
