### PR TITLE
Add rake task migration to generate empty files

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,14 @@ That will create the table to keep track of rake task migrations.
 
 ## Usage
 
-Create the `lib/tasks/migrations.rake` file and add your tasks:
+Create the `lib/tasks/#{timestamp}_migration_namespace.rake` file using command:
+
+    $ bundle exec rake tasks:generate migration_namespace
+
+and add your tasks:
 
 ```ruby
-namespace :migrations do
+namespace :migration_namespace do
   task :migrate_user_names => :environment do
     User.find_each do |user|
       user.update_attributes(name: "#{user.first_name} #{user.last_name}")

--- a/lib/tasks/task_migration.rake
+++ b/lib/tasks/task_migration.rake
@@ -3,6 +3,17 @@ namespace :tasks do
   task migrate: :environment do
     Rake::TaskMigration.migrate
   end
+
+  desc 'Generate an empty task file with timestamp, Usage => rake tasks:create task_name'
+  task generate: :environment do
+    argument = ARGV[1]
+    task_name = "#{argument}_#{Time.now.to_formatted_s(:number)}.rake"
+    puts "#{task_name}: generating"
+    task_path = "lib/tasks/migrations/#{task_name}"
+    FileUtils.touch(task_path)
+    puts "#{task_name}: generated"
+    exit
+  end
 end
 
 namespace :task_migration do

--- a/lib/tasks/task_migration.rake
+++ b/lib/tasks/task_migration.rake
@@ -7,7 +7,7 @@ namespace :tasks do
   desc 'Generate an empty task file with timestamp, Usage => rake tasks:create task_name'
   task generate: :environment do
     argument = ARGV[1]
-    task_name = "#{argument}_#{Time.now.to_formatted_s(:number)}.rake"
+    task_name = "#{Time.now.to_formatted_s(:number)}_#{argument}.rake"
     puts "#{task_name}: generating"
     task_path = "lib/tasks/migrations/#{task_name}"
     FileUtils.touch(task_path)


### PR DESCRIPTION
This PR adds `rake tasks:generate` command to generate migration task files under `lib/tasks/migrations` folder