### PR TITLE
allow bypassing transaction wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Use an initializer file for configuration.
 - `migration_table_name (default = 'rake_task_migrations')`
 - `migration_namespace (default = :migrations)`
 - `wrap_migrations_in_transaction (default = true)`
+
 #### Example:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Use an initializer file for configuration.
 
 - `migration_table_name (default = 'rake_task_migrations')`
 - `migration_namespace (default = :migrations)`
-
+- `wrap_migrations_in_transaction (default = true)`
 #### Example:
 
 ```ruby
@@ -69,6 +69,7 @@ Use an initializer file for configuration.
 Rake::TaskMigration.config do |config|
   config.migration_table_name = 'table_name'
   config.migration_namespace  = 'namespace'
+  config.wrap_migrations_in_transaction = false
 end
 ```
 

--- a/lib/rake/task_migration.rb
+++ b/lib/rake/task_migration.rb
@@ -16,6 +16,9 @@ module Rake
     mattr_accessor :migration_namespace
     self.migration_namespace  = DEFAULT_NAMESPACE
 
+    mattr_accessor :wrap_migrations_in_transaction
+    self.wrap_migrations_in_transaction = true
+
     class << self
       def config
         yield self

--- a/lib/rake/task_migration/migrator.rb
+++ b/lib/rake/task_migration/migrator.rb
@@ -28,7 +28,7 @@ module Rake
 
         announce "#{task}: migrating"
 
-        ActiveRecord::Base.transaction do
+        with_optional_transaction_wrapper do
           time = Benchmark.measure do
             invoke(task)
           end
@@ -41,6 +41,14 @@ module Rake
           migration.save!
 
           announce "#{task}: migrated (#{format('%.4fs', time.real)})"
+        end
+      end
+
+      def with_optional_transaction_wrapper
+        if Rake::TaskMigration.wrap_migrations_in_transaction
+          ActiveRecord::Base.transaction { yield }
+        else
+          yield
         end
       end
 


### PR DESCRIPTION
See also https://github.com/zaccari/rake-task-migrations/issues/16

 - adds a configurable option `wrap_migrations_in_transaction` which defaults to `true` to preserve existing behavior
 - if `wrap_migrations_in_transaction` is false, don't wrap the task invocation in a database transaction